### PR TITLE
Update k8s/kro.yaml for kro v0.2.3

### DIFF
--- a/k8s/kro.yaml
+++ b/k8s/kro.yaml
@@ -1,5 +1,5 @@
 apiVersion: kro.run/v1alpha1
-kind: ResourceGroup
+kind: ResourceGraphDefinition
 metadata:
   name: application
 spec:


### PR DESCRIPTION
Kro is still in alpha and in v0.2.3 ResourceGroup was replaced by ResourceGraphDefinition.